### PR TITLE
XIVY-632 Add MandatoryFilter hint and generate ViewColumns appropriate

### DIFF
--- a/db-meta-plugin/pom.xml
+++ b/db-meta-plugin/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>maven-plugin</packaging>
 	
 	<!-- format: <ivy-release>.<databaseversion><counter> -->
-	<version>9.4.103-SNAPSHOT</version>
+	<version>9.4.107-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/db-meta-plugin/src/main/java/ch/ivyteam/db/meta/generator/internal/JavaClassGenerator.java
+++ b/db-meta-plugin/src/main/java/ch/ivyteam/db/meta/generator/internal/JavaClassGenerator.java
@@ -42,7 +42,7 @@ public abstract class JavaClassGenerator implements IMetaOutputGenerator
   private String fTargetPackage;
 
   /** The tables to generate entity classes for */
-  private List<String> fTablesToGenerateJavaClassFor = new ArrayList<String>();
+  private final List<String> fTablesToGenerateJavaClassFor = new ArrayList<String>();
 
   /** Database System Name */
   public static final String JAVA = "Java";
@@ -115,6 +115,9 @@ public abstract class JavaClassGenerator implements IMetaOutputGenerator
 
   /** Table has legacy security member fields, defined in either Role or User table. */
   public static final String SECURITY_MEMBER_LEGACY_FIELDS = "SecurityMemberLegacyFields";
+
+  /** View column is a mandatory filter */
+  public static final String MANDATORY_FILTER = "MandatoryFilter";
 
   @Override
   public void analyseArgs(String[] args) throws Exception

--- a/db-meta-plugin/src/main/java/ch/ivyteam/db/meta/generator/internal/persistency/ViewColumnInfo.java
+++ b/db-meta-plugin/src/main/java/ch/ivyteam/db/meta/generator/internal/persistency/ViewColumnInfo.java
@@ -21,20 +21,24 @@ public class ViewColumnInfo
   {
     this.column = column;
   }
-  
+
   public String getName()
   {
     return column.getId();
   }
-  
+
   public String getAlias()
   {
     return column.getDatabaseManagementSystemHints(JavaClassGenerator.JAVA).getHintValue(JavaClassGenerator.QUERY_FIELD_NAME);
   }
-  
+
   public String getConstant()
   {
     return new ConstantBuilder(getName()).toConstant();
+  }
+
+  public boolean isMandatoryFilter() {
+    return column.getDatabaseManagementSystemHints(JavaClassGenerator.JAVA).isHintSet(JavaClassGenerator.MANDATORY_FILTER);
   }
 
   public static List<ViewColumnInfo> getViewColumns(SqlTable table, SqlMeta meta)

--- a/db-meta-plugin/src/main/java/ch/ivyteam/db/meta/model/internal/SqlDatabaseSystemHintValidator.java
+++ b/db-meta-plugin/src/main/java/ch/ivyteam/db/meta/model/internal/SqlDatabaseSystemHintValidator.java
@@ -43,7 +43,7 @@ public class SqlDatabaseSystemHintValidator
     registerHint(COMMON_HINT_KEY, SqlScriptGenerator.INDEX_NAME);
     registerHint(COMMON_HINT_KEY, SqlScriptGenerator.NO_INDEX);
     registerHint(COMMON_HINT_KEY, SqlScriptGenerator.DEFAULT_VALUE);
-    
+
     registerType(JavaClassGenerator.JAVA);
     registerHint(JavaClassGenerator.JAVA, JavaClassGenerator.ADDITIONAL_SET_METHODS);
     registerHint(JavaClassGenerator.JAVA, JavaClassGenerator.AS_ASSOCIATION);
@@ -64,6 +64,7 @@ public class SqlDatabaseSystemHintValidator
     registerHint(JavaClassGenerator.JAVA, JavaClassGenerator.DEPRECATED);
     registerHint(JavaClassGenerator.JAVA, JavaClassGenerator.CUSTOM_FIELDS);
     registerHint(JavaClassGenerator.JAVA, JavaClassGenerator.SECURITY_MEMBER_LEGACY_FIELDS);
+    registerHint(JavaClassGenerator.JAVA, JavaClassGenerator.MANDATORY_FILTER);
     registerHint(JavaClassGenerator.JAVA, TableInfo.BUSINESS_CLASS);
 
     registerType(JavaEntityClassGenerator.CACHE);
@@ -84,11 +85,11 @@ public class SqlDatabaseSystemHintValidator
     registerType(PostgreSqlSqlScriptGenerator.POSTGRESQL);
     registerHint(PostgreSqlSqlScriptGenerator.POSTGRESQL, PostgreSqlSqlScriptGenerator.CAST);
   }
-    
+
   private static void registerHint(String type, String hint)
   {
     Set<String> databaseManagementSystemHint = HINTS_PER_TYPE.get(type);
-    
+
     if (databaseManagementSystemHint == null)
     {
       databaseManagementSystemHint = new HashSet<String>();
@@ -98,9 +99,9 @@ public class SqlDatabaseSystemHintValidator
   }
 
   /**
-   * @param type 
+   * @param type
    * @param hint
-   * @return - 
+   * @return -
    */
   public static boolean isKnownHint(String type, String hint)
   {
@@ -110,7 +111,7 @@ public class SqlDatabaseSystemHintValidator
     }
     return true;
   }
-  
+
   private static boolean checkHint(String type, String hint)
   {
     Set<String> databaseManagementSystemHint = HINTS_PER_TYPE.get(type);
@@ -120,14 +121,14 @@ public class SqlDatabaseSystemHintValidator
     }
     return databaseManagementSystemHint.contains(hint);
   }
-  
+
   private static void registerType(String type)
   {
     HINT_TYPES.add(type);
   }
-  
+
   /**
-   * @param type 
+   * @param type
    * @return -
    */
   public static boolean isKnownType(String type)

--- a/db-meta-plugin/src/main/resources/ch/ivyteam/db/meta/generator/internal/persistency/JavaClassForView.ftl
+++ b/db-meta-plugin/src/main/resources/ch/ivyteam/db/meta/generator/internal/persistency/JavaClassForView.ftl
@@ -5,7 +5,7 @@ import ch.ivyteam.db.sql.ColumnName;
 public class ${className}
 {
   public static final String VIEWNAME = "${view.id}";
-<#list columns as column>  
+<#list columns as column>
 
   private static final String COLUMN_NAME_${column.constant} = "${column.name}";
 

--- a/db-meta-plugin/src/main/resources/ch/ivyteam/db/meta/generator/internal/persistency/JavaClassPersistencyServiceImplementation.ftl
+++ b/db-meta-plugin/src/main/resources/ch/ivyteam/db/meta/generator/internal/persistency/JavaClassPersistencyServiceImplementation.ftl
@@ -11,7 +11,7 @@ import ch.ivyteam.ivy.persistence.restricted.db.meta.Table;
 import ch.ivyteam.ivy.persistence.restricted.db.meta.TableColumn;
 import ch.ivyteam.ivy.persistence.restricted.db.meta.TableColumn.Type;
 import ch.ivyteam.ivy.persistence.restricted.db.meta.TableColumn.Option;
-<#if table.query??>  
+<#if table.query??>
 import ch.ivyteam.ivy.persistence.restricted.db.meta.ViewColumn;
 </#if>
 import ch.ivyteam.ivy.persistence.PersistencyException;
@@ -24,66 +24,66 @@ public class Db${table.simpleEntityClass} extends DatabaseTableClassPersistencyS
 
   public static final String TABLENAME = "${table.name}";
 
-<#if table.query??>  
+<#if table.query??>
   public static final String QUERY_TABLENAME = "${table.query}";
 
 </#if>
   private static final String PRIMARY_KEY_COLUMN_NAME = "${table.primaryKey.name}";
   public static final ColumnName PRIMARY_KEY_COLUMN = new ColumnName(TABLENAME, PRIMARY_KEY_COLUMN_NAME);
 
-<#if table.parentKey??>  
+<#if table.parentKey??>
   private static final String PARENT_FOREIGN_KEY_COLUMN_NAME = "${table.parentKey.name}";
   public static final ColumnName PARENT_FOREIGN_KEY_COLUMN = new ColumnName(TABLENAME, PARENT_FOREIGN_KEY_COLUMN_NAME);
 
 </#if>
-<#if table.fieldForOptimisticLocking??>  
+<#if table.fieldForOptimisticLocking??>
   private static final String OPTIMISTIC_LOCKING_COLUMN_NAME = "${table.fieldForOptimisticLocking.name}";
 
   public static final ColumnName OPTIMISTIC_LOCKING_COLUMN = new ColumnName(TABLENAME, OPTIMISTIC_LOCKING_COLUMN_NAME);
 
 </#if>
-<#list columns as column>  
+<#list columns as column>
   private static final String COLUMN_NAME_${column.constant} = "${column.name}";
   public static final ColumnName COLUMN_${column.constant} = new ColumnName(TABLENAME, COLUMN_NAME_${column.constant});
 
 </#list>
-<#list associations as association>  
+<#list associations as association>
   public static final String ASSOCIATION_${association.constant}_TABLE_NAME = "${association.table}";
 
   public static final ColumnName ASSOCIATION_${association.constant}_COLUMN_${association.foreignKeyConstant} = new ColumnName(ASSOCIATION_${association.constant}_TABLE_NAME, "${association.foreignKey}");
 
 </#list>
   public Db${table.simpleEntityClass}(DatabasePersistencyService database) {
-    super(database, 
+    super(database,
       ${table.simpleEntityClass}.class,
       new Table(
-        TABLENAME, 
+        TABLENAME,
         KeyType.${table.primaryKey.keyType},
-        Arrays.asList( 
+        Arrays.asList(
 <#list columns as column>
   <#if column.isPrimaryKey()>
           new TableColumn(PRIMARY_KEY_COLUMN, Type.${table.primaryKey.sqlDataType}, Option.PRIMARY_KEY)<#if column_has_next>,</#if>
   <#elseif column.isParentKey()>
           new TableColumn(PARENT_FOREIGN_KEY_COLUMN, Type.${table.primaryKey.sqlDataType}, Option.PARENT_KEY)<#if column_has_next>,</#if>
-  <#else> 
+  <#else>
           new TableColumn(COLUMN_${column.constant}, Type.${column.sqlDataType}<#if column.isOptimisticLockingColumn()>, Option.USE_FOR_OPTIMISTICAL_LOCKING</#if><#if column.isLob()>, Option.LARGE_OBJECT</#if>)<#if column_has_next>,</#if>
-  </#if>         
+  </#if>
 </#list>
 <#if table.query??>
         ),
 <#else>
         )
-</#if>        
+</#if>
 <#if table.query??>
         QUERY_TABLENAME,
-        Arrays.asList( 
+        Arrays.asList(
    <#list queryViewColumns as column>
           new ViewColumn(QueryView.VIEW_COLUMN_${column.constant}<#if column.alias??>, "${column.alias}"</#if><#if column.isMandatoryFilter()>, ViewColumn.Option.MANDATORY_FILTER</#if>)<#if column_has_next>,</#if>
   </#list>
         )
 </#if>
       )
-    ); 
+    );
   }
 
   @Override
@@ -91,22 +91,22 @@ public class Db${table.simpleEntityClass} extends DatabaseTableClassPersistencyS
 <#assign row=1>
     return new ${table.simpleEntityClass}(
       database.get${table.primaryKey.method}(result, ${row}${table.primaryKey.additionalReadArgs})<#if (columnsWithoutPrimaryParentAndLob?size > 0 || table.parentKey??)>,</#if>
-<#assign row=row+1>      
+<#assign row=row+1>
 <#if table.parentKey??>
       database.get${table.parentKey.method}(result, ${row}${table.parentKey.additionalReadArgs})<#if (columnsWithoutPrimaryParentAndLob?size > 0)>,</#if>
-  <#assign row=row+1>      
-</#if>            
+  <#assign row=row+1>
+</#if>
 <#list columnsWithoutPrimaryParentAndLob as column>
   <#if column.isPassword()>
     <#if column.optionalPasswordColumn??>
       database.optionalDecode(transaction, database.get${column.optionalPasswordColumn.method}(result, ${column.optionalPasswordColumn.resultSetRowNumber}${column.optionalPasswordColumn.additionalReadArgs}), database.get${column.method}(result, ${row}${column.additionalReadArgs}))<#if column_has_next>,</#if>
-    <#else> 
+    <#else>
       database.decode(transaction, database.get${column.method}(result, ${row}${column.additionalReadArgs}))<#if column_has_next>,</#if>
     </#if>
   <#else>
       database.get${column.method}(result, ${row}${column.additionalReadArgs})<#if column_has_next>,</#if>
   </#if>
-  <#assign row=row+1>      
+  <#assign row=row+1>
 </#list>
     );
   }
@@ -114,9 +114,9 @@ public class Db${table.simpleEntityClass} extends DatabaseTableClassPersistencyS
   @Override
   protected void writeDataToUpdateStatement(IPersistentTransaction transaction, ${table.simpleEntityClass} data, PreparedStatement stmt) {
 <#assign row=1>
-<#if table.parentKey??>      
+<#if table.parentKey??>
     database.set${table.parentKey.method}(stmt, ${row}, ${table.parentKey.additionalWriteArgs}, PARENT_FOREIGN_KEY_COLUMN);
-  <#assign row=row+1>      
+  <#assign row=row+1>
 </#if>
 <#list columnsWithoutPrimaryParentAndLob as column>
   <#if column.isOptimisticLockingColumn()>
@@ -133,7 +133,7 @@ public class Db${table.simpleEntityClass} extends DatabaseTableClassPersistencyS
 <#assign row=1>
     database.set${table.primaryKey.method}(stmt, ${row}, ${table.primaryKey.additionalWriteArgs}, PRIMARY_KEY_COLUMN);
 <#assign row=row+1>
-<#if table.parentKey??>      
+<#if table.parentKey??>
     database.set${table.parentKey.method}(stmt, ${row}, ${table.parentKey.additionalWriteArgs}, PARENT_FOREIGN_KEY_COLUMN);
   <#assign row=row+1>
 </#if>
@@ -148,7 +148,7 @@ public class Db${table.simpleEntityClass} extends DatabaseTableClassPersistencyS
   protected void writeDataToOptimisticUpdateStatement(IPersistentTransaction transaction, ${table.simpleEntityClass} data, PreparedStatement stmt) {
     database.set${table.fieldForOptimisticLocking.method}(stmt, ${numberOfColumns}, data.get${table.fieldForOptimisticLocking.name}(), COLUMN_${table.fieldForOptimisticLocking.constant});
   }
-</#if>  
+</#if>
 <#if table.query??>
 
   public static class QueryView {
@@ -158,5 +158,5 @@ public class Db${table.simpleEntityClass} extends DatabaseTableClassPersistencyS
     public static final ColumnName VIEW_COLUMN_${column.constant} = new ColumnName(QUERY_TABLENAME, VIEW_COLUMN_NAME_${column.constant});
 </#list>
   }
-</#if>  
+</#if>
 }

--- a/db-meta-plugin/src/main/resources/ch/ivyteam/db/meta/generator/internal/persistency/JavaClassPersistencyServiceImplementation.ftl
+++ b/db-meta-plugin/src/main/resources/ch/ivyteam/db/meta/generator/internal/persistency/JavaClassPersistencyServiceImplementation.ftl
@@ -78,7 +78,7 @@ public class Db${table.simpleEntityClass} extends DatabaseTableClassPersistencyS
         QUERY_TABLENAME,
         Arrays.asList( 
    <#list queryViewColumns as column>
-          new ViewColumn(QueryView.VIEW_COLUMN_${column.constant}<#if column.alias??>, "${column.alias}"</#if>)<#if column_has_next>,</#if>
+          new ViewColumn(QueryView.VIEW_COLUMN_${column.constant}<#if column.alias??>, "${column.alias}"</#if><#if column.isMandatoryFilter()>, ViewColumn.Option.MANDATORY_FILTER</#if>)<#if column_has_next>,</#if>
   </#list>
         )
 </#if>

--- a/db-meta-plugin/src/test/java/ch/ivyteam/db/meta/generator/internal/TestLocalizedView.java
+++ b/db-meta-plugin/src/test/java/ch/ivyteam/db/meta/generator/internal/TestLocalizedView.java
@@ -1,0 +1,80 @@
+package ch.ivyteam.db.meta.generator.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import ch.ivyteam.db.meta.model.internal.SqlMeta;
+import ch.ivyteam.db.meta.model.internal.SqlView;
+import ch.ivyteam.db.meta.parser.internal.Parser;
+import ch.ivyteam.db.meta.parser.internal.Scanner;
+
+public class TestLocalizedView
+{
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void parseAst() throws Exception
+  {
+    SqlMeta meta = parse();
+    SqlView view = meta.getArtifacts(SqlView.class).get(0);
+
+    assertThat(view.toString()).isEqualTo(
+          "CREATE VIEW IWA_CaseQuery(\n" +
+          "  CaseId,\n" +
+          "  Name,\n" +
+          "  LanguageId)\n" +
+          "AS SELECT\n" +
+          "  IWA_Case.TaskId,\n" +
+          "  IWA_CaseLocalized.Name,\n" +
+          "  IWA_CaseLocalized.LanguageId\n" +
+          "FROM IWA_Case INNER JOIN IWA_CaseLocalized ON IWA_Case.CaseId=IWA_CaseLocalized.CaseId");
+  }
+
+  @Test
+  public void createJavaClassPersistencyServiceImplemenation() throws FileNotFoundException, Exception {
+    SqlMeta meta = parse();
+    File outputDirectory = tempFolder.newFolder();
+
+    var generator = new JavaClassPersistencyServiceImplementationGenerator();
+    generator.analyseArgs(new String[] {
+        "-outputDir", outputDirectory.getAbsolutePath(),
+        "-package", "ch.ivyteam.db",
+        "-entityPackage", "ch.ivyteam.data",
+        "-tables", "IWA_Case"});
+    generator.generateMetaOutput(meta);
+    String generatedJavaClass = FileUtils.readFileToString(new File(outputDirectory, "ch/ivyteam/db/DbCaseData.java"));
+    String originalJavaClass = loadTestResource("DbCaseData.java");
+    assertThat(generatedJavaClass).isEqualTo(originalJavaClass);
+  }
+
+  private String loadTestResource(String name) throws IOException
+  {
+    try (InputStream is = TestComplexView.class.getResourceAsStream(name))
+    {
+      return IOUtils.toString(is);
+    }
+  }
+
+  private SqlMeta parse() throws FileNotFoundException, Exception
+  {
+    try(InputStreamReader isr = new InputStreamReader(TestLocalizedView.class.getResourceAsStream("localizedView.meta")))
+    {
+      Scanner scanner = new Scanner(isr);
+      Parser parser = new Parser(scanner);
+      SqlMeta sqlMetaDefinition = (SqlMeta)parser.parse().value;
+      return sqlMetaDefinition;
+    }
+  }
+}

--- a/db-meta-plugin/src/test/resources/ch/ivyteam/db/meta/generator/internal/DbCaseData.java
+++ b/db-meta-plugin/src/test/resources/ch/ivyteam/db/meta/generator/internal/DbCaseData.java
@@ -1,0 +1,80 @@
+package ch.ivyteam.db;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+import ch.ivyteam.ivy.persistence.IPersistentTransaction;
+import ch.ivyteam.ivy.persistence.restricted.db.meta.KeyType;
+import ch.ivyteam.ivy.persistence.restricted.db.meta.Table;
+import ch.ivyteam.ivy.persistence.restricted.db.meta.TableColumn;
+import ch.ivyteam.ivy.persistence.restricted.db.meta.TableColumn.Type;
+import ch.ivyteam.ivy.persistence.restricted.db.meta.TableColumn.Option;
+import ch.ivyteam.ivy.persistence.restricted.db.meta.ViewColumn;
+import ch.ivyteam.ivy.persistence.PersistencyException;
+import ch.ivyteam.ivy.persistence.db.DatabasePersistencyService;
+import ch.ivyteam.ivy.persistence.db.DatabaseTableClassPersistencyService;
+import ch.ivyteam.db.sql.ColumnName;
+import ch.ivyteam.data.CaseData;
+
+public class DbCaseData extends DatabaseTableClassPersistencyService<CaseData> {
+
+  public static final String TABLENAME = "IWA_Case";
+
+  public static final String QUERY_TABLENAME = "IWA_CaseQuery";
+
+  private static final String PRIMARY_KEY_COLUMN_NAME = "CaseId";
+  public static final ColumnName PRIMARY_KEY_COLUMN = new ColumnName(TABLENAME, PRIMARY_KEY_COLUMN_NAME);
+
+  private static final String COLUMN_NAME_CASE_ID = "CaseId";
+  public static final ColumnName COLUMN_CASE_ID = new ColumnName(TABLENAME, COLUMN_NAME_CASE_ID);
+
+  public DbCaseData(DatabasePersistencyService database) {
+    super(database, 
+      CaseData.class,
+      new Table(
+        TABLENAME, 
+        KeyType.LONG,
+        Arrays.asList( 
+          new TableColumn(PRIMARY_KEY_COLUMN, Type.BIGINT, Option.PRIMARY_KEY)
+        ),
+        QUERY_TABLENAME,
+        Arrays.asList( 
+          new ViewColumn(QueryView.VIEW_COLUMN_CASE_ID),
+          new ViewColumn(QueryView.VIEW_COLUMN_NAME),
+          new ViewColumn(QueryView.VIEW_COLUMN_LANGUAGE_ID, ViewColumn.Option.MANDATORY_FILTER)
+        )
+      )
+    ); 
+  }
+
+  @Override
+  protected CaseData createObjectFromResultSet(IPersistentTransaction transaction, ResultSet result) throws PersistencyException, SQLException {
+    return new CaseData(
+      database.getLong(result, 1)
+    );
+  }
+
+  @Override
+  protected void writeDataToUpdateStatement(IPersistentTransaction transaction, CaseData data, PreparedStatement stmt) {
+    database.setLong(stmt, 1, data.getCaseId(), PRIMARY_KEY_COLUMN);
+  }
+
+  @Override
+  protected void writeDataToInsertStatement(IPersistentTransaction transaction, CaseData data, PreparedStatement stmt) {
+    database.setLong(stmt, 1, data.getCaseId(), PRIMARY_KEY_COLUMN);
+  }
+
+  public static class QueryView {
+
+    private static final String VIEW_COLUMN_NAME_CASE_ID = "CaseId";
+    public static final ColumnName VIEW_COLUMN_CASE_ID = new ColumnName(QUERY_TABLENAME, VIEW_COLUMN_NAME_CASE_ID);
+
+    private static final String VIEW_COLUMN_NAME_NAME = "Name";
+    public static final ColumnName VIEW_COLUMN_NAME = new ColumnName(QUERY_TABLENAME, VIEW_COLUMN_NAME_NAME);
+
+    private static final String VIEW_COLUMN_NAME_LANGUAGE_ID = "LanguageId";
+    public static final ColumnName VIEW_COLUMN_LANGUAGE_ID = new ColumnName(QUERY_TABLENAME, VIEW_COLUMN_NAME_LANGUAGE_ID);
+  }
+}

--- a/db-meta-plugin/src/test/resources/ch/ivyteam/db/meta/generator/internal/DbCaseData.java
+++ b/db-meta-plugin/src/test/resources/ch/ivyteam/db/meta/generator/internal/DbCaseData.java
@@ -31,22 +31,22 @@ public class DbCaseData extends DatabaseTableClassPersistencyService<CaseData> {
   public static final ColumnName COLUMN_CASE_ID = new ColumnName(TABLENAME, COLUMN_NAME_CASE_ID);
 
   public DbCaseData(DatabasePersistencyService database) {
-    super(database, 
+    super(database,
       CaseData.class,
       new Table(
-        TABLENAME, 
+        TABLENAME,
         KeyType.LONG,
-        Arrays.asList( 
+        Arrays.asList(
           new TableColumn(PRIMARY_KEY_COLUMN, Type.BIGINT, Option.PRIMARY_KEY)
         ),
         QUERY_TABLENAME,
-        Arrays.asList( 
+        Arrays.asList(
           new ViewColumn(QueryView.VIEW_COLUMN_CASE_ID),
           new ViewColumn(QueryView.VIEW_COLUMN_NAME),
           new ViewColumn(QueryView.VIEW_COLUMN_LANGUAGE_ID, ViewColumn.Option.MANDATORY_FILTER)
         )
       )
-    ); 
+    );
   }
 
   @Override

--- a/db-meta-plugin/src/test/resources/ch/ivyteam/db/meta/generator/internal/localizedView.meta
+++ b/db-meta-plugin/src/test/resources/ch/ivyteam/db/meta/generator/internal/localizedView.meta
@@ -1,0 +1,41 @@
+CREATE TABLE IWA_Language
+(
+  LanguageId BIGINT NOT NULL,
+  Locale VARCHAR(200) NOT NULL,
+  PRIMARY KEY (LanguageId)
+);  
+
+CREATE TABLE IWA_Case
+(
+  CaseId BIGINT NOT NULL,
+  PRIMARY KEY (CaseId)
+)
+FOR Java USE(
+  QueryTableName='IWA_CaseQuery'); 
+
+CREATE TABLE IWA_LocalizedCase
+(
+  -- Identifies the user.
+  CaseLocalizedId VARCHAR(200) NOT NULL,
+  CaseId BIGINT NOT NULL REFERENCES IWA_Case(CaseId),
+  LanguageId BIGINT NOT NULL REFERENCES IWA_Language (LanguageId),
+  -- Name of the user. The name identifies a user within a web application.
+  Name VARCHAR(200) NOT NULL,
+  PRIMARY KEY (CaseLocalizedId)
+);  
+  
+CREATE VIEW IWA_CaseQuery
+(
+  CaseId,
+  Name, 
+  LanguageId
+    FOR Java USE (MandatoryFilter)
+)
+AS SELECT 
+  IWA_Case.TaskId,
+  IWA_CaseLocalized.Name,
+  IWA_CaseLocalized.LanguageId
+FROM IWA_Case
+INNER JOIN IWA_CaseLocalized ON IWA_Case.CaseId = IWA_CaseLocalized.CaseId; 
+
+


### PR DESCRIPTION
The new hint MandatoryFilter can be set on View columns. The
JavaClassPersistencyServiceImplementationGenerator uses it to generate
the ViewColumn with the ViewColumn.Option MandatoryFilter.